### PR TITLE
Fix client data to be optional in ControlWithItems.set

### DIFF
--- a/lib/wx/core/controlwithitems.rb
+++ b/lib/wx/core/controlwithitems.rb
@@ -127,7 +127,9 @@ class Wx::ControlWithItems
     end
     wx_set.bind(self).call(items)
     client_data_store.clear
-    items.each_with_index { |item, ix| set_client_data(item, data[ix]) }
+    if data
+      items.each_with_index { |item, ix| set_client_data(item, data[ix]) }
+    end
   end
 
   wx_clear = instance_method :clear


### PR DESCRIPTION
The docs say the parameter is optional, but if you don't pass an argument, it throws an exception. This fixes it to be optional.